### PR TITLE
Bubble up errors from plugin to terraform-docs core

### DIFF
--- a/plugin/server.go
+++ b/plugin/server.go
@@ -73,6 +73,7 @@ func (s *server) Version(args interface{}, resp *string) error {
 
 // Execute returns the generated output.
 func (s *server) Execute(args ExecuteArgs, resp *string) error {
-	*resp, _ = s.impl.Execute(args)
-	return nil
+	r, err := s.impl.Execute(args)
+	*resp = r
+	return err
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/Jt3Hr if this is your first time opening a
terraform-docs pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

If there's any error in plugin, e.g. in gotemplate, the error was
suppressed and user would be in the dark of what has happened. This
will bubble up the error down from plugin up to terraform-core.

I have:

- [x] Read and followed terraform-docs' [contribution process].

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/Jt3Hr
