### PR TITLE
Add 'ShowDefault' and 'ShowType' settings

### DIFF
--- a/print/settings.go
+++ b/print/settings.go
@@ -107,4 +107,10 @@ type Settings struct {
 	// default: true
 	// scope: Global
 	ShowResources bool
+
+	// ShowType show "Type" column when generating Markdown or AsciiDoc
+	//
+	// default: true
+	// scope: Asciidoc, Markdown
+	ShowType bool
 }

--- a/print/settings.go
+++ b/print/settings.go
@@ -24,7 +24,7 @@ type Settings struct {
 	// scope: Markdown
 	EscapeCharacters bool
 
-	// IndentLevel control the indentation of AsciiDoc and Markdown headers [available: 1, 2, 3, 4, 5]
+	// IndentLevel control the indentation of headers [available: 1, 2, 3, 4, 5]
 	//
 	// default: 2
 	// scope: Asciidoc, Markdown
@@ -42,7 +42,7 @@ type Settings struct {
 	// scope: Pretty
 	ShowColor bool
 
-	// ShowDefault show "Default" column when generating Markdown
+	// ShowDefault show "Default" column
 	//
 	// default: true
 	// scope: Asciidoc, Markdown
@@ -84,13 +84,13 @@ type Settings struct {
 	// scope: Global
 	ShowProviders bool
 
-	// ShowRequired show "Required" column when generating Markdown
+	// ShowRequired show "Required" column
 	//
 	// default: true
 	// scope: Asciidoc, Markdown
 	ShowRequired bool
 
-	// ShowSensitivity show "Sensitive" column when generating Markdown
+	// ShowSensitivity show "Sensitive" column
 	//
 	// default: true
 	// scope: Asciidoc, Markdown
@@ -108,7 +108,7 @@ type Settings struct {
 	// scope: Global
 	ShowResources bool
 
-	// ShowType show "Type" column when generating Markdown or AsciiDoc
+	// ShowType show "Type" column
 	//
 	// default: true
 	// scope: Asciidoc, Markdown

--- a/print/settings.go
+++ b/print/settings.go
@@ -30,7 +30,7 @@ type Settings struct {
 	// scope: Asciidoc, Markdown
 	IndentLevel int
 
-	// OutputValues ailrghaekrgj
+	// OutputValues extract and show Output values from Terraform module output
 	//
 	// default: false
 	// scope: Global
@@ -41,6 +41,12 @@ type Settings struct {
 	// default: true
 	// scope: Pretty
 	ShowColor bool
+
+	// ShowDefault show "Default" column when generating Markdown
+	//
+	// default: true
+	// scope: Asciidoc, Markdown
+	ShowDefault bool
 
 	// ShowHeader show "Header" module information
 	//
@@ -81,13 +87,13 @@ type Settings struct {
 	// ShowRequired show "Required" column when generating Markdown
 	//
 	// default: true
-	// scope: Markdown
+	// scope: Asciidoc, Markdown
 	ShowRequired bool
 
 	// ShowSensitivity show "Sensitive" column when generating Markdown
 	//
 	// default: true
-	// scope: Markdown
+	// scope: Asciidoc, Markdown
 	ShowSensitivity bool
 
 	// ShowRequirements show "Requirements" section


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/Jt3Hr if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

- add `ShowDefault` settings to control visibility of input's "default" column
- add `ShowType` settings to control visibility of input's "type" column.

xref: https://github.com/terraform-docs/terraform-docs/issues/312

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Not applicable.

[contribution process]: https://git.io/Jt3Hr
