### PR TITLE
Add HasFooter() back to Module interface

### DIFF
--- a/print/settings.go
+++ b/print/settings.go
@@ -48,17 +48,17 @@ type Settings struct {
 	// scope: Asciidoc, Markdown
 	ShowDefault bool
 
-	// ShowHeader show "Header" module information
-	//
-	// default: true
-	// scope: Global
-	ShowHeader bool
-
 	// ShowFooter show "footer" module information
 	//
 	// default: false
 	// scope: Global
 	ShowFooter bool
+
+	// ShowHeader show "Header" module information
+	//
+	// default: true
+	// scope: Global
+	ShowHeader bool
 
 	// ShowInputs show "Inputs" information
 	//

--- a/terraform/module.go
+++ b/terraform/module.go
@@ -35,7 +35,7 @@ type Module interface {
 	HasHeader() bool
 
 	// HasFooter indicates if the module has footer.
-	// HasFooter() bool
+	HasFooter() bool
 
 	// HasInputs indicates if the module has inputs.
 	HasInputs() bool


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/Jt3Hr if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

xref: #19 
xref: https://github.com/terraform-docs/terraform-docs/pull/383

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

not applicable.

[contribution process]: https://git.io/Jt3Hr
