### PR TITLE
Render templates by their name

### DIFF
--- a/template/template_test.go
+++ b/template/template_test.go
@@ -71,7 +71,7 @@ func TestTemplateRender(t *testing.T) {
 			settings := &print.Settings{}
 			tpl := New(settings, tt.items...)
 			tpl.CustomFunc(customFuncs)
-			rendered, err := tpl.Render(module)
+			rendered, err := tpl.Render("", module)
 			if tt.wantErr {
 				assert.NotNil(err)
 			} else {


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/Jt3Hr if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Instead of always executing first `template.Items`, this PR adds the ability to
execute named template. If name is empty it attempts to find the first item (if
exists) otherwise errors out.

xref: https://github.com/terraform-docs/terraform-docs/issues/486

I have:

- [x] Read and followed terraform-docs' [contribution process].
- [x] All tests pass when I run `make test`.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

No new test is needed.

[contribution process]: https://git.io/Jt3Hr
